### PR TITLE
Fix iOS Auto-linking + Build

### DIFF
--- a/RNDeviceTimeFormat.podspec
+++ b/RNDeviceTimeFormat.podspec
@@ -11,11 +11,11 @@ Pod::Spec.new do |s|
   s.author       = { "Steffen Agger" => "steffen.agger@gmail.com" }
   s.platform     = :ios, "7.0"
   s.source       = { :git => "https://github.com/author/RNDeviceTimeFormat.git", :tag => "#{s.version}"}
-  s.source_files  = "*.{h,m}"
+  s.source_files  = "ios/*.{h,m}"
   s.requires_arc = true
 
 
-  s.dependency "React"
+  s.dependency "React-Core"
 
 end
 


### PR DESCRIPTION
* Updated the podspec so that it's in the root of the project, which is necessary for auto-linking in React Native.
* Fixed the source_files so that it is properly prefixed with ios given the podspec location change.
* Updated the React dependency so that it uses React-Core, which is necessary to get it to build successfully on the latest release version of RN (0.69.x).